### PR TITLE
取消开机自配置无线导致其他设备无法配置

### DIFF
--- a/scripts/lean.sh
+++ b/scripts/lean.sh
@@ -14,7 +14,7 @@ ln -sf ./feeds/luci/applications/luci-app-cpufreq ./package/feeds/luci/luci-app-
 sed -i 's,1608,1800,g' feeds/luci/applications/luci-app-cpufreq/root/etc/uci-defaults/cpufreq
 sed -i 's,2016,2208,g' feeds/luci/applications/luci-app-cpufreq/root/etc/uci-defaults/cpufreq
 sed -i 's,1512,1608,g' feeds/luci/applications/luci-app-cpufreq/root/etc/uci-defaults/cpufreq
-
+rm -rf ./target/linux/rockchip/armv8/base-files/etc/hotplug.d
 # Clone community packages to package/community
 mkdir package/community
 pushd package/community


### PR DESCRIPTION
不只是mt7621u  还要用烤螃蟹网卡